### PR TITLE
Allow overlap checker to work with specified days only

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - `PAGERDUTY_READ_ONLY_TOKEN` is used for reading schedules and checking the overlaps.
 - `SCHEDULES` array can contain one or more `SCHEDULE` items to check
 - every `SCHEDULE` should have a `NOTIFICATIONS` to create incident or send message if overlap is found
+- `SCHEDULE` can contain a `DAYS` key, which speficies numbers of days in UTC (0 = Sunday) for verification (`[0, 1, 2, 3, 4]` below represents days without weekend)
 
 Currently, we only support Slack (`SLACK` with `SLACK_WEBHOOK_URL` and `CHANNEL`) and PagerDuty (`PAGERDUTY_TOKEN`) notifications.
 
@@ -35,7 +36,8 @@ Currently, we only support Slack (`SLACK` with `SLACK_WEBHOOK_URL` and `CHANNEL`
 		"SCHEDULE": ["PWEVPB6", "PT57OLA"],
 		"NOTIFICATIONS": {
 			"PAGERDUTY_TOKEN": "22222222222222222222"
-		}
+		},
+		"DAYS": [0, 1, 2, 3, 4]
 	}]
 }
 ```

--- a/test/fixtures/config-days.json
+++ b/test/fixtures/config-days.json
@@ -1,0 +1,16 @@
+{
+  "PAGERDUTY_API_URL": "https://acme.pagerduty.com/api/v1",
+  "PAGERDUTY_READ_ONLY_TOKEN": "E7px6VVr3PVHZPJq51oa",
+  "WEEKS_TO_CHECK": 2,
+  "SCHEDULES": [{
+    "SCHEDULE": ["PWEVPB6", "PT57OLG"],
+    "NOTIFICATIONS": {
+      "SLACK": {
+        "SLACK_WEBHOOK_URL": "https://incomingUrl/",
+        "CHANNEL": "#channel-name"
+      },
+      "PAGERDUTY_TOKEN" : "111111111111"
+    },
+    "DAYS": [0, 1, 2, 3, 4]
+  }]
+}

--- a/test/fixtures/entries-days.json
+++ b/test/fixtures/entries-days.json
@@ -1,0 +1,35 @@
+{
+  "total": 3,
+  "entries": [
+    {
+      "user": {
+        "email": "gregory_hilll@deckow.us",
+        "name": "Gregory",
+        "color": "chocolate",
+        "id": "PRT2T0A"
+      },
+      "end": "2012-08-17T12:00:00-04:00",
+      "start": "2012-08-17T00:00:00-04:00"
+    },
+    {
+      "user": {
+        "email": "hailie_hansen@shieldsfarrell.biz",
+        "name": "Halie",
+        "color": "maroon",
+        "id": "PFKNVH3"
+      },
+      "end": "2012-08-20T00:00:00-04:00",
+      "start": "2012-08-19T12:00:00-04:00"
+    },
+    {
+      "user": {
+        "email": "gabrielle_glover@mertz.biz",
+        "name": "Gabriel",
+        "color": "dark-red",
+        "id": "PYBBUSQ"
+      },
+      "end": "2012-08-20T00:00:00-04:00",
+      "start": "2012-08-20T00:00:00-04:00"
+    }
+  ]
+}


### PR DESCRIPTION
In order to allow check for overlaps amongst User and Platform support, filtering on Days has to be implemented (supports are shared during the weekend). 

Configuration key `DAYS` was added in order to specify the valid days for the check.