### PR TITLE
Fix incident creation and slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - `SCHEDULE` can contain a `EXCLUSION_DAYS` key, which specifies days (3 letter abb.) in form of object with optional `start` and `end` time (`hh:mm` format). If `start` or `end` is omitted, whole day is considered excluded. 
 Example below represents current weekend on-call setup. All datetimes are translated to UTC, so feel free to use a local time.
 
-Currently, we only support Slack (`SLACK` with `SLACK_WEBHOOK_URL` and `CHANNEL`) and PagerDuty (`PAGERDUTY_TOKEN`) notifications.
+Currently, we only support Slack (`SLACK` with `SLACK_WEBHOOK_URL` and `CHANNEL`) or shorthanded `SLACK_WEBHOOK_URL` and PagerDuty (`PAGERDUTY_TOKEN`) notifications.
 
 ```json
 {
@@ -36,7 +36,8 @@ Currently, we only support Slack (`SLACK` with `SLACK_WEBHOOK_URL` and `CHANNEL`
 	}, {
 		"SCHEDULE": ["PWEVPB6", "PT57OLA"],
 		"NOTIFICATIONS": {
-			"PAGERDUTY_TOKEN": "22222222222222222222"
+			"PAGERDUTY_TOKEN": "22222222222222222222",
+			"SLACK_WEBHOOK_URL": "http://acme.slack.com/11111",
 		},
 		"EXCLUSION_DAYS": {"Fri": {"start": "16:00", "end": "23:59"}, "Sat": {}, "Sun": {"start": "00:00", "end": "16:00"}}
 	}]

--- a/src/notify.coffee
+++ b/src/notify.coffee
@@ -16,7 +16,7 @@ createPagerDutyIncident = (options, message, cb) ->
       json:
         service_key: options.serviceKey
         event_type: "trigger",
-        description: options.description or message
+        description: message or options.description[0] # description is an array - https://github.com/apiaryio/pagerduty-overlap-checker/blob/master/src/pagerduty.coffee#L154
         details:
           options.details
 
@@ -55,13 +55,13 @@ send = (options, message, cb) ->
 
   async.parallel [
     (next) ->
-        if options['SLACK']?
+        if options['SLACK'] or options['SLACK_WEBHOOK_URL']?
           debug('Found Slack webhook, sending a notification')
           slackMessage = {}
           slackMessage.text = formatMessage(message)
-          slackMessage.channel = options['SLACK']['CHANNEL']
+          slackMessage.channel = options['SLACK']?['CHANNEL']
           slackOptions = {}
-          slackOptions.webhookUrl = options['SLACK']['SLACK_WEBHOOK_URL']
+          slackOptions.webhookUrl = options['SLACK']?['SLACK_WEBHOOK_URL'] or options['SLACK_WEBHOOK_URL']
           createSlackMessage slackOptions, slackMessage, next
         else
           debug('No Slack webhook defined')

--- a/src/notify.coffee
+++ b/src/notify.coffee
@@ -10,16 +10,15 @@ createPagerDutyIncident = (options, message, cb) ->
   unless options.serviceKey
     cb new Error "Missing PD service key"
   else
+
     request
       uri:  'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
       method: "POST"
       json:
         service_key: options.serviceKey
         event_type: "trigger",
-        description: message or options.description[0] # description is an array - https://github.com/apiaryio/pagerduty-overlap-checker/blob/master/src/pagerduty.coffee#L154
-        details:
-          options.details
-
+        description: "On-call overlap found!"
+        details: message
     , (err, res, body) ->
       if body?.errors?.length > 0
         err ?= new Error "INCIDENT_CREATION_FAILED Cannot create event: #{JSON.stringify body.errors}"
@@ -46,9 +45,25 @@ formatMessage = (messages, option = 'plain') ->
   if typeof messages is 'string'
     return messages
   else
-    outputMessage = messages.join('\n')
-    debug('Notification - formatMessage: ', outputMessage)
-    return outputMessage
+    switch option
+      when 'plain'
+        outputMessage = "_Following overlaps found:_\n"
+        for message in messages
+          outputMessage += """#{message.user}: #{message.schedules[0]} and #{message.schedules[1]} on #{message.date.toLocaleString()}\n"""
+      when 'markdown'
+        outputMessage = "Following overlaps found:\n"
+        for message in messages
+          outputMessage += """*#{message.user}:* `#{message.schedules[0]}` and `#{message.schedules[1]}` on #{message.date.toLocaleString()}\n"""
+      when 'json'
+        outputMessage = messages.reduce((acc, curr)->
+          acc[curr.user] ?= []
+          acc[curr.user].push("#{curr.schedules[0]} and #{curr.schedules[1]} on #{curr.date.toLocaleString()}")
+          return acc
+        , {})
+
+  debug('Notification - formatMessage option: ', option)
+  debug('Notification - formatMessage: ', outputMessage)
+  return outputMessage
 
 send = (options, message, cb) ->
   debug('send:', options, message)
@@ -58,7 +73,7 @@ send = (options, message, cb) ->
         if options['SLACK'] or options['SLACK_WEBHOOK_URL']?
           debug('Found Slack webhook, sending a notification')
           slackMessage = {}
-          slackMessage.text = formatMessage(message)
+          slackMessage.text = formatMessage(message, 'markdown')
           slackMessage.channel = options['SLACK']?['CHANNEL']
           slackOptions = {}
           slackOptions.webhookUrl = options['SLACK']?['SLACK_WEBHOOK_URL'] or options['SLACK_WEBHOOK_URL']
@@ -72,9 +87,7 @@ send = (options, message, cb) ->
           pdOptions = {}
           pdOptions.serviceKey = options['PAGERDUTY_TOKEN']
           pdOptions.description = message
-          pdOptions.details =
-            subject: "PagerDuty overlap incident"
-          createPagerDutyIncident pdOptions, formatMessage(message), next
+          createPagerDutyIncident pdOptions, formatMessage(message, 'json'), next
         else
           debug('No PD token defined')
           next()

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -64,7 +64,7 @@ checkSchedulesIds = (cb) ->
   for ids in configSchedules
     listIds.push ids['SCHEDULE']
   debug("Schedules Ids from config: ", _.flatten(listIds))
-  configSchedulesIds =  _.flatten(listIds)
+  configSchedulesIds =  _.uniq(_.flatten(listIds))
   getSchedulesIds (err, schedulesIds) ->
     if err then return cb err
     debug('intersection: ', _.intersection(configSchedulesIds, schedulesIds).length)
@@ -126,6 +126,10 @@ processSchedules = (allSchedules, days = [], cb) ->
           overlap = false
           startDate = new Date(myStart)
           day = getDayAbbrev(startDate.getUTCDay())
+
+          message = """Overlapping duty found for user #{myUserName}
+              from #{myStart} to #{myEnd} on schedule ID #{schedule.id}!"""
+
           if myStart <= crossCheckEntry.start < myEnd and
               crossCheckEntry.user.id == myUserId
             overlap = true
@@ -144,13 +148,12 @@ processSchedules = (allSchedules, days = [], cb) ->
 
 
                 if exclusionStartDate <= startDate < exclusionEndDate
+                  debug('excluded:', message)
                   overlap = false
               else
                 overlap = false
 
           if overlap
-            message = """Overlapping duty found for user #{myUserName}
-              from #{myStart} to #{myEnd} on schedule ID #{schedule.id}!"""
             messages.push message
   debug(_.uniq(messages))
   if messages.length is 0

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -53,8 +53,17 @@ getSchedulesIds = (cb) ->
     if err
       console.log "Cannot get request:", err
       return cb err
-    schedulesIds = _.pluck(body.schedules, "id")
+
+    schedulesIds = []
+
+    for schedule in body.schedules
+      schedulesIds.push(schedule.id)
+      # UWAGA UWAGA - side effect follows!
+      # it's easier, cheaper and more comprehensive to load schedule names here and temporarily store them using nconf
+      nconf.set("schedulesNames:#{schedule.id}", schedule.name)
+
     debug("Schedules Ids from PD: ", schedulesIds)
+    debug("Schedules Names from PD: ", debug(nconf.get("schedulesNames")))
     cb null, schedulesIds
 
 # Check if all schedules defined in config are available in PD
@@ -107,6 +116,7 @@ processSchedules = (allSchedules, days = [], cb) ->
   if typeof days is 'function'
     [cb, days] = [days, []]
   messages = []
+  duplicities = {}
   debug('allSchedules:', allSchedules)
   for schedule in allSchedules
     debug('schedule:', schedule)
@@ -121,14 +131,17 @@ processSchedules = (allSchedules, days = [], cb) ->
       debug(myUserId)
       myUserName = entry.user.name
       debug(myUserName)
+      duplicities.myUserName ?= []
       for crossSchedule in otherSchedules
         for crossCheckEntry in crossSchedule.entries
           overlap = false
           startDate = new Date(myStart)
           day = getDayAbbrev(startDate.getUTCDay())
 
-          message = """Overlapping duty found for user #{myUserName}
-              from #{myStart} to #{myEnd} on schedule ID #{schedule.id}!"""
+          scheduleId = nconf.get("schedulesNames:#{schedule.id}")
+          crossScheduleId = nconf.get("schedulesNames:#{crossSchedule.id}")
+
+          message = {user: myUserName, schedules: [scheduleId, crossScheduleId], date: startDate}
 
           if myStart <= crossCheckEntry.start < myEnd and
               crossCheckEntry.user.id == myUserId
@@ -153,7 +166,8 @@ processSchedules = (allSchedules, days = [], cb) ->
               else
                 overlap = false
 
-          if overlap
+          if overlap and crossCheckEntry.start not in duplicities.myUserName
+            duplicities.myUserName.push(crossCheckEntry.start)
             messages.push message
   debug(_.uniq(messages))
   if messages.length is 0

--- a/test/pagerduty-test.coffee
+++ b/test/pagerduty-test.coffee
@@ -92,7 +92,7 @@ describe 'Compare schedules', ->
             "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PWEVPB6!",
             "Overlapping duty found for user Gregory\nfrom 2012-08-19T00:00:00-04:00 to 2012-08-19T12:00:00-04:00 on schedule ID PT57OLG!",
             "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PT57OLG!"
-          ],
+          ].join('\n'),
           details:{subject:"PagerDuty overlap incident"}
       }
       nock('https://events.pagerduty.com/generic/2010-04-15/')
@@ -143,7 +143,7 @@ describe 'Compare schedules on specific days', ->
         description:[
           "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PWEVPB6!",
           "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PT57OLG!",
-        ],
+        ].join('\n'),
         details:{subject:"PagerDuty overlap incident"}
       }
 

--- a/test/pagerduty-test.coffee
+++ b/test/pagerduty-test.coffee
@@ -87,13 +87,8 @@ describe 'Compare schedules', ->
       expectedBody = {
           service_key:"111111111111",
           event_type:"trigger",
-          description:[
-            "Overlapping duty found for user Gregory\nfrom 2012-08-19T00:00:00-04:00 to 2012-08-19T12:00:00-04:00 on schedule ID PWEVPB6!",
-            "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PWEVPB6!",
-            "Overlapping duty found for user Gregory\nfrom 2012-08-19T00:00:00-04:00 to 2012-08-19T12:00:00-04:00 on schedule ID PT57OLG!",
-            "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PT57OLG!"
-          ].join('\n'),
-          details:{subject:"PagerDuty overlap incident"}
+          description:"On-call overlap found!"
+          details:{"Gregory":["""Primary and Secondary on #{new Date("2012-08-19T00:00:00-04:00").toLocaleString()}"""],"Halie":["Primary and Secondary on #{new Date("2012-08-19T12:00:00-04:00").toLocaleString()}"]}
       }
       nock('https://events.pagerduty.com/generic/2010-04-15/')
         .post('/create_event.json', expectedBody)
@@ -110,12 +105,14 @@ describe 'Compare schedules', ->
           message = msg
           done err
 
-  it 'Check returned messages if containes "Overlapping duty found for user"', ->
+  it 'Check returned messages if containes "Primary and Secondary"', ->
     assert.isArray message
-    assert.lengthOf message, 4
+    assert.lengthOf message, 2
     for singleMessage in message
       debug(singleMessage)
-      assert.include singleMessage, 'Overlapping duty found for user'
+      assert.isObject singleMessage
+      assert.include singleMessage.schedules, "Primary"
+      assert.include singleMessage.schedules, "Secondary"
 
 
 describe 'Compare schedules on specific days', ->
@@ -140,11 +137,8 @@ describe 'Compare schedules on specific days', ->
       expectedBody = {
         service_key:"111111111111",
         event_type:"trigger",
-        description:[
-          "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PWEVPB6!",
-          "Overlapping duty found for user Halie\nfrom 2012-08-19T12:00:00-04:00 to 2012-08-20T00:00:00-04:00 on schedule ID PT57OLG!",
-        ].join('\n'),
-        details:{subject:"PagerDuty overlap incident"}
+        description: "On-call overlap found!"
+        details:{"Halie":["Primary and Secondary on #{new Date("2012-08-19T12:00:00-04:00").toLocaleString()}"]}
       }
 
       nock('https://events.pagerduty.com/generic/2010-04-15/')
@@ -162,12 +156,14 @@ describe 'Compare schedules on specific days', ->
           message = msg
           done err
 
-  it 'Check returned messages if containes "Overlapping duty found for user"', ->
+  it 'Check returned messages if containes "Primary and Secondary"', ->
     assert.isArray message
-    assert.lengthOf message, 2
+    assert.lengthOf message, 1
     for singleMessage in message
       debug(singleMessage)
-      assert.include singleMessage, 'Overlapping duty found for user'
+      assert.isObject singleMessage
+      assert.include singleMessage.schedules, "Primary"
+      assert.include singleMessage.schedules, "Secondary"
 
 
 describe 'Get user id', ->


### PR DESCRIPTION
Notifying on Slack and incident creation is not not working - this PR is fixing it and enables it for same schedules in config.

It was manually tested with current schedules and incidents were (not) created as expected.

Also formatting was adjusted and more options were added. 

Slack:
![screen shot 2017-06-13 at 17 46 28](https://user-images.githubusercontent.com/5753758/27091429-5d1956c6-5060-11e7-84d0-b51db3c6cb45.png)

PagerDuty:
![screen shot 2017-06-13 at 17 16 44](https://user-images.githubusercontent.com/5753758/27091436-61c1b25e-5060-11e7-924b-4cfe341e8bf7.png)
